### PR TITLE
Change Serial read strategy

### DIFF
--- a/utils/interface.py
+++ b/utils/interface.py
@@ -255,8 +255,9 @@ class Interface:
         self.data = []
 
         while self.is_reading:
-            line = self.serial.readline()
-            self.process_line(line)
+            lines = self.serial.readlines()
+            for line in lines:
+                self.process_line(line)
 
     def stop_read(self):
         """" Call this method to terminate serial reading


### PR DESCRIPTION
Retrieve all data from the buffer at once. That way there is no risk of buffer overflow is the reading frequency is lower than the data reception rate

## What's new?

- Now the buffer is emptied each time it is read. Complete lines are processed. Incomplete lines are saved for later (ie. next buffer read)